### PR TITLE
Add read_session tool for cross-session context retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Added
+
+- `read_session` tool for reading conversation transcripts from previous sessions
+- Session ID reference in `/handoff` command template to enable cross-session context retrieval
+
+### Changed
+
+- Updated `/handoff` command template to include session reference line and formatted output structure
+
 ## [0.1.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Inspired by Amp's handoff command - see their [post](https://ampcode.com/news/ha
 - `/handoff <goal>` command that analyzes the conversation and generates a continuation prompt
 - Guides the AI to include relevant `@file` references so the next session starts with context loaded
 - Opens a new session with the prompt as an editable draft
+- `read_session` tool for retrieving full conversation transcripts from previous sessions when the handoff summary isn't sufficient
 
 ## Requirements
 
@@ -52,6 +53,24 @@ ln -sf ~/.config/opencode/opencode-handoff/src/plugin.ts ~/.config/opencode/plug
 ```
 
 The AI analyzes the conversation, extracts key decisions and relevant files, generates a focused prompt, and creates a new session with that prompt ready to edit.
+
+### Reading Previous Session Transcripts
+
+When you use `/handoff`, the generated prompt includes a session reference line:
+
+```
+Continuing work from session sess_01jxyz123. When you lack specific information you can use read_session to get it.
+```
+
+This gives the AI in the new session access to the `read_session` tool, which can fetch the full conversation transcript from the source session. If the handoff summary doesn't include something you need, just ask - the AI can look it up.
+
+**Example:**
+
+```
+You: What were the specific error messages we saw earlier?
+```
+
+The AI will use `read_session` to retrieve details from the previous session that weren't included in the handoff summary.
 
 ## Contributing
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,46 @@
 import type { Plugin } from "@opencode-ai/plugin"
 import { tool } from "@opencode-ai/plugin"
 
+function formatTranscript(messages: Array<{ info: any; parts: any[] }>, limit?: number): string {
+  const lines: string[] = []
+  
+  for (const msg of messages) {
+    if (msg.info.role === "user") {
+      lines.push("## User")
+      for (const part of msg.parts) {
+        if (part.type === "text" && !part.ignored) {
+          lines.push(part.text)
+        }
+        if (part.type === "file") {
+          lines.push(`[Attached: ${part.filename || "file"}]`)
+        }
+      }
+      lines.push("")
+    }
+    
+    if (msg.info.role === "assistant") {
+      lines.push("## Assistant")  
+      for (const part of msg.parts) {
+        if (part.type === "text") {
+          lines.push(part.text)
+        }
+        if (part.type === "tool" && part.state.status === "completed") {
+          lines.push(`[Tool: ${part.tool}] ${part.state.title}`)
+        }
+      }
+      lines.push("")
+    }
+  }
+  
+  const output = lines.join("\n").trim()
+  
+  if (messages.length >= (limit ?? 100)) {
+    return output + `\n\n(Showing ${messages.length} most recent messages. Use a higher 'limit' to see more.)`
+  }
+  
+  return output + `\n\n(End of session - ${messages.length} messages)`
+}
+
 export const HandoffPlugin: Plugin = async (ctx) => ({
   config: async (config) => {
     config.command = config.command || {}
@@ -16,15 +56,23 @@ A good handoff frontloads everything the next session needs so it can start impl
 
 Analyze this conversation and extract what matters for continuing the work.
 
-1. FILE REFERENCES (Required)
+## OUTPUT FORMAT
 
+1. LINE 1 (Required)
+   
+   Always start with exactly this line, replacing the placeholder with the current session ID:
+   
+   Continuing work from session [CURRENT_SESSION_ID]. When you lack specific information you can use read_session to get it.
+
+2. FILE REFERENCES
+   
    Include all relevant @file references on a SINGLE LINE, space-separated.
 
    Why: Every @file gets loaded into context automatically. The next session won't need to search—the files are already there. This eliminates exploration entirely.
 
    Include files that will be edited, dependencies being touched, relevant tests, configs, and key reference docs. Be generous—the cost of an extra file is low; missing a critical one means another archaeology dig. Target 8-15 files, up to 20 for complex work.
 
-2. CONTEXT AND GOAL
+3. CONTEXT AND GOAL
 
    After the files, describe what we're working on and provide whatever context helps continue the work. Structure it based on what fits the conversation—could be tasks, findings, a simple paragraph, or detailed steps.
 
@@ -63,6 +111,33 @@ After generating the handoff message, IMMEDIATELY call handoff_prepare with the 
         })
 
         return "Handoff prompt created in new session. Review and edit before sending."
+      }
+    }),
+
+    read_session: tool({
+      description: "Read the conversation transcript from a previous session. Use this when you need specific information from the source session that wasn't included in the handoff summary.",
+      args: {
+        sessionID: tool.schema.string().describe("The full session ID (e.g., sess_01jxyz...)"),
+        limit: tool.schema.number().optional().describe("Maximum number of messages to read (defaults to 100, max 500)"),
+      },
+      async execute(args, context) {
+        const limit = Math.min(args.limit ?? 100, 500)
+        
+        try {
+          const response = await ctx.client.session.messages({
+            path: { id: args.sessionID },
+            query: { limit }
+          })
+          
+          if (!response.data || response.data.length === 0) {
+            return "Session has no messages or does not exist."
+          }
+          
+          const formatted = formatTranscript(response.data, limit)
+          return formatted
+        } catch (error) {
+          return `Could not read session ${args.sessionID}: ${error instanceof Error ? error.message : 'Unknown error'}`
+        }
       }
     })
   }


### PR DESCRIPTION
Adds the `read_session` tool to enable the AI to fetch full conversation transcripts from previous sessions when the handoff summary isn't sufficient.

## Changes

- Add `read_session` tool with sessionID and optional limit parameters
- Update `/handoff` command template to include session reference line
- Add documentation for the new functionality in README and CHANGELOG

Inspired by Amp Code's read_thread functionality.