### PR TITLE
Fix: Add configuration flag to prevent `handoff` from firing on all clients when using a shared server

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,29 @@ Optionally, pin to a specific version for stability:
 
 OpenCode fetches unpinned plugins from npm on each startup; pinned versions are cached and require a manual version bump to update.
 
+## Configuration
+
+### `serverClient.enabled`
+
+When running `opencode serve` with multiple `opencode attach` clients, the `/handoff` command broadcasts to all connected clients by default — every client navigates to a new session with the same prompt.
+
+Set `serverClient.enabled` to `true` to use direct API calls instead of TUI broadcasts. This ensures only the server-side session is affected, leaving other attached clients undisturbed.
+
+```json
+{
+  "plugin": [["opencode-handoff", { "serverClient": { "enabled": true } }]]
+}
+```
+
+**Behavior difference:**
+
+| Setting | Behavior |
+|---------|----------|
+| `serverClient.enabled: false` (default) | Opens a new session as an editable draft via TUI broadcast |
+| `serverClient.enabled: true` | Creates a new session and sends the prompt via API — the new session starts processing immediately |
+
+> **Note:** When `serverClient.enabled: true`, the handoff prompt is sent directly to the new session without an editable draft step. The AI in the new session begins working immediately.
+
 ## Usage
 
 1. Have a conversation in OpenCode with some context

--- a/README.md
+++ b/README.md
@@ -47,9 +47,23 @@ Set `serverClient.enabled` to `true` to use direct API calls instead of TUI broa
 
 ```json
 {
-  "plugin": [["opencode-handoff", { "serverClient": { "enabled": true } }]]
+  "plugin": 
+    ["opencode-handoff", { 
+      "serverClient": { "enabled": true } 
+    }],
 }
 ```
+
+Alternatively, if you have manually cloned the repository:  
+```json 
+{
+  "plugin": 
+    ["/complete/path/to/cloned/repository", { 
+      "serverClient": { "enabled": true } 
+    }],
+}
+```
+
 
 **Behavior difference:**
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Alternatively, if you have manually cloned the repository:
 | Setting | Behavior |
 |---------|----------|
 | `serverClient.enabled: false` (default) | Opens a new session as an editable draft via TUI broadcast |
-| `serverClient.enabled: true` | Creates a new session and sends the prompt via API — the new session starts processing immediately |
+| `serverClient.enabled: true` | Creates a new session and sends the prompt via API — the new session starts processing immediately. You remain in your current session and must switch to the new one manually. |
 
-> **Note:** When `serverClient.enabled: true`, the handoff prompt is sent directly to the new session without an editable draft step. The AI in the new session begins working immediately.
+> **Note:** When `serverClient.enabled: true`, the handoff prompt is sent directly to the new session without an editable draft step. The AI in the new session begins working immediately. You remain in your current session — switch to the new one via `/sessions` in the TUI or `opencode attach` in a terminal.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Set `serverClient.enabled` to `true` to use direct API calls instead of TUI broa
   "plugin": 
     ["opencode-handoff", { 
       "serverClient": { "enabled": true } 
-    }],
+    }]
 }
 ```
 
@@ -60,7 +60,7 @@ Alternatively, if you have manually cloned the repository:
   "plugin": 
     ["/complete/path/to/cloned/repository", { 
       "serverClient": { "enabled": true } 
-    }],
+    }]
 }
 ```
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -41,7 +41,8 @@ USER: $ARGUMENTS
 After generating the handoff message, IMMEDIATELY call handoff_session with your prompt and files:
 \`handoff_session(prompt="...", files=["src/foo.ts", "src/bar.ts", ...])\``
 
-export const HandoffPlugin: Plugin = async (ctx) => {
+export const HandoffPlugin: Plugin = async (ctx, options) => {
+  const serverClient = { enabled: (options as { serverClient?: { enabled?: boolean } } | undefined)?.serverClient?.enabled === true }
   const processedSessions = new Set<string>()
 
   return {
@@ -54,7 +55,7 @@ export const HandoffPlugin: Plugin = async (ctx) => {
     },
 
     tool: {
-      handoff_session: HandoffSession(ctx.client),
+      handoff_session: HandoffSession(ctx.client, serverClient),
       read_session: ReadSession(ctx.client),
     },
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -17,9 +17,7 @@ export type OpencodeClient = PluginInput["client"]
  * Takes the OpenCode client as a dependency for TUI and session operations.
  */
 export const HandoffSession = (client: OpencodeClient, serverClient: { enabled: boolean }) => {
-  return tool({
-    description: "Create a new session with the handoff prompt as an editable draft",
-    args: {
+    description: "Create a new session with the handoff prompt (editable draft via TUI by default; direct API send when serverClient.enabled is true)",
       prompt: tool.schema.string().describe("The generated handoff prompt"),
       files: tool.schema.array(tool.schema.string()).optional().describe("Array of file paths to load into the new session's context"),
     },

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -17,7 +17,9 @@ export type OpencodeClient = PluginInput["client"]
  * Takes the OpenCode client as a dependency for TUI and session operations.
  */
 export const HandoffSession = (client: OpencodeClient, serverClient: { enabled: boolean }) => {
+  return tool({
     description: "Create a new session with the handoff prompt (editable draft via TUI by default; direct API send when serverClient.enabled is true)",
+    args: {
       prompt: tool.schema.string().describe("The generated handoff prompt"),
       files: tool.schema.array(tool.schema.string()).optional().describe("Array of file paths to load into the new session's context"),
     },

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -16,7 +16,7 @@ export type OpencodeClient = PluginInput["client"]
  *
  * Takes the OpenCode client as a dependency for TUI and session operations.
  */
-export const HandoffSession = (client: OpencodeClient) => {
+export const HandoffSession = (client: OpencodeClient, serverClient: { enabled: boolean }) => {
   return tool({
     description: "Create a new session with the handoff prompt as an editable draft",
     args: {
@@ -32,24 +32,42 @@ export const HandoffSession = (client: OpencodeClient) => {
         ? `${sessionReference}\n\n${fileRefs}\n\n${args.prompt}`
         : `${sessionReference}\n\n${args.prompt}`
 
-      await client.tui.executeCommand({ body: { command: "session_new" } })
-      // session_new is fire-and-forget (publishes a bus event, returns immediately).
-      // The TUI needs time to navigate to the home screen and mount the new prompt
-      // input before appendPrompt can insert text — otherwise the event is silently
-      // dropped because the input component doesn't exist yet.
-      await new Promise(r => setTimeout(r, 150))
-      await client.tui.appendPrompt({ body: { text: fullPrompt } })
-
-      await client.tui.showToast({
-        body: {
-          title: "Handoff Ready",
-          message: "Review and edit the draft, then send",
-          variant: "success",
-          duration: 4000,
+      if (serverClient.enabled) {
+        // Use session API when the server client is enabled (no TUI broadcasts)
+        try {
+          const newSession = await client.session.create()
+          if (!newSession.data?.id) {
+            return "Failed to create new session: no session ID returned"
+          }
+          await client.session.promptAsync({
+            path: { id: newSession.data.id },
+            body: { parts: [{ type: "text", text: fullPrompt }] },
+          })
+          return "Handoff session created and prompt sent. The new session has started processing the handoff."
+        } catch (error) {
+          return `Failed to create handoff session: ${error instanceof Error ? error.message : 'Unknown error'}`
         }
-      })
+      } else {
+        // Default: use TUI broadcast behavior
+        await client.tui.executeCommand({ body: { command: "session_new" } })
+        // session_new is fire-and-forget (publishes a bus event, returns immediately).
+        // The TUI needs time to navigate to the home screen and mount the new prompt
+        // input before appendPrompt can insert text — otherwise the event is silently
+        // dropped because the input component doesn't exist yet.
+        await new Promise(r => setTimeout(r, 150))
+        await client.tui.appendPrompt({ body: { text: fullPrompt } })
 
-      return "Handoff prompt created in new session. Review and edit before sending."
+        await client.tui.showToast({
+          body: {
+            title: "Handoff Ready",
+            message: "Review and edit the draft, then send",
+            variant: "success",
+            duration: 4000,
+          }
+        })
+
+        return "Handoff prompt created in new session. Review and edit before sending."
+      }
     }
   })
 }


### PR DESCRIPTION
Fixes: https://github.com/joshuadavidthomas/opencode-handoff/issues/21

**Problem**: /handoff in multi-client server mode broadcasts forced all of them navigate to a new session.
**Proposed solution**: The handoff is not automatically sent to all opencode clients; it is printed as the last message of the session and the user can simple copy it (<leader>y, by default) then open a new session and paste.
This behaviour is off by default and can be enabled by a configuration flag.  
Added `serverClient.enabled` config option.  

