### PR TITLE
test: cover package behavior

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_call:
+
+concurrency:
+  group: test-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test
+        run: bun test

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "main": "src/plugin.ts",
   "files": ["src", "README.md"],
   "scripts": {
+    "test": "bun test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/test/files.test.ts
+++ b/test/files.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { buildSyntheticFileParts, parseFileReferences } from "../src/files"
+
+describe("parseFileReferences", () => {
+  test("extracts unique file references and ignores email and backtick-prefixed references", () => {
+    const refs = parseFileReferences(
+      "Load @src/plugin.ts and @./README.md, then @src/plugin.ts again. " +
+        "Ignore name@example.com and `@ignored.ts`, but keep @extensionless."
+    )
+
+    expect([...refs]).toEqual([
+      "src/plugin.ts",
+      "./README.md",
+      "extensionless",
+    ])
+  })
+})
+
+describe("buildSyntheticFileParts", () => {
+  test("builds Read-compatible parts and skips unsuitable references", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "opencode-handoff-files-"))
+
+    try {
+      const textPath = join(directory, "note.txt")
+      await writeFile(textPath, "alpha\nbeta")
+      await writeFile(join(directory, "archive.bin"), new Uint8Array([0, 1, 2]))
+      await mkdir(join(directory, "nested"))
+
+      const parts = await buildSyntheticFileParts(
+        directory,
+        new Set(["note.txt", "archive.bin", "nested", "missing.txt"])
+      )
+
+      expect(parts).toEqual([
+        {
+          type: "text",
+          synthetic: true,
+          text: `Called the Read tool with the following input: ${JSON.stringify({ filePath: textPath })}`,
+        },
+        {
+          type: "text",
+          synthetic: true,
+          text: [
+            "<file>",
+            "00001| alpha",
+            "00002| beta",
+            "",
+            "(End of file - total 2 lines)",
+            "</file>",
+          ].join("\n"),
+        },
+      ])
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { HandoffPlugin } from "../src/plugin"
+import type { OpencodeClient } from "../src/tools"
+
+function createPluginInput(
+  directory: string,
+  client: OpencodeClient
+): PluginInput {
+  return {
+    client,
+    directory,
+    worktree: directory,
+    project: {},
+    serverUrl: new URL("http://localhost"),
+    $: {},
+  } as unknown as PluginInput
+}
+
+describe("HandoffPlugin", () => {
+  test("registers the handoff command and tools", async () => {
+    const client = {} as OpencodeClient
+    const hooks = await HandoffPlugin(createPluginInput("/tmp/project", client))
+    const freshConfig: {
+      command?: Record<string, { description: string; template: string }>
+    } = {}
+    await hooks.config!(freshConfig as never)
+    expect(freshConfig.command?.handoff).toBeDefined()
+
+    const config: {
+      command: Record<string, { description: string; template: string }>
+    } = {
+      command: {
+        existing: { description: "Existing command", template: "keep me" },
+      },
+    }
+    await hooks.config!(config as never)
+
+    expect(config.command.existing).toEqual({
+      description: "Existing command",
+      template: "keep me",
+    })
+    expect(config.command.handoff?.template).toContain("USER: $ARGUMENTS")
+    expect(hooks.tool?.handoff_session).toBeDefined()
+    expect(hooks.tool?.read_session).toBeDefined()
+  })
+
+  test("injects referenced files once and resets after session deletion", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "opencode-handoff-plugin-"))
+
+    try {
+      await writeFile(join(directory, "note.txt"), "handoff context")
+      const promptCalls: unknown[] = []
+      const client = {
+        session: {
+          async prompt(input: unknown) {
+            promptCalls.push(input)
+          },
+        },
+      } as unknown as OpencodeClient
+      const hooks = await HandoffPlugin(createPluginInput(directory, client))
+      const message = {
+        message: {
+          sessionID: "sess_next",
+          model: { providerID: "provider", modelID: "model" },
+          agent: "build",
+        },
+        parts: [
+          {
+            type: "text",
+            synthetic: true,
+            text: "Continuing work from session ignored @missing.txt",
+          },
+          {
+            type: "text",
+            text: "Continuing work from session sess_source @note.txt",
+          },
+        ],
+      }
+
+      await hooks["chat.message"]!(
+        { sessionID: "sess_next" } as never,
+        {
+          message: message.message,
+          parts: [{ type: "text", text: "ordinary message @note.txt" }],
+        } as never
+      )
+      expect(promptCalls).toHaveLength(0)
+
+      await hooks["chat.message"]!(
+        { sessionID: "sess_next" } as never,
+        message as never
+      )
+      await hooks["chat.message"]!(
+        { sessionID: "sess_next" } as never,
+        message as never
+      )
+
+      expect(promptCalls).toHaveLength(1)
+      const promptCall = promptCalls[0] as {
+        path: { id: string }
+        body: {
+          noReply: boolean
+          model: unknown
+          agent: string
+          parts: Array<{ synthetic?: boolean; text: string }>
+        }
+      }
+      expect(promptCall).toMatchObject({
+        path: { id: "sess_next" },
+        body: {
+          noReply: true,
+          model: { providerID: "provider", modelID: "model" },
+          agent: "build",
+        },
+      })
+      expect(promptCall.body.parts).toHaveLength(2)
+      expect(promptCall.body.parts.every((part) => part.synthetic)).toBe(true)
+      expect(promptCall.body.parts.map((part) => part.text).join("\n")).toContain(
+        "handoff context"
+      )
+      expect(promptCall.body.parts.map((part) => part.text).join("\n")).not.toContain(
+        "missing.txt"
+      )
+
+      await hooks.event!({
+        event: {
+          type: "session.deleted",
+          properties: { info: { id: "sess_next" } },
+        },
+      } as never)
+      await hooks["chat.message"]!(
+        { sessionID: "sess_next" } as never,
+        message as never
+      )
+
+      expect(promptCalls).toHaveLength(2)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test"
+import type { ToolContext } from "@opencode-ai/plugin"
+import { HandoffSession, ReadSession, type OpencodeClient } from "../src/tools"
+
+function createToolContext(sessionID: string): ToolContext {
+  return {
+    sessionID,
+    messageID: "msg_test",
+    agent: "build",
+    directory: "/tmp/project",
+    worktree: "/tmp/project",
+    abort: new AbortController().signal,
+    metadata() {},
+    async ask() {},
+  }
+}
+
+describe("HandoffSession", () => {
+  test("opens a new session with an editable handoff draft", async () => {
+    const calls: Array<{ name: string; input: unknown }> = []
+    const client = {
+      tui: {
+        async executeCommand(input: unknown) {
+          calls.push({ name: "executeCommand", input })
+        },
+        async appendPrompt(input: unknown) {
+          calls.push({ name: "appendPrompt", input })
+        },
+        async showToast(input: unknown) {
+          calls.push({ name: "showToast", input })
+        },
+      },
+    } as unknown as OpencodeClient
+
+    const result = await HandoffSession(client).execute(
+      {
+        prompt: "Continue implementation",
+        files: ["src/files.ts", "@README.md"],
+      },
+      createToolContext("sess_source")
+    )
+
+    expect(calls.map((call) => call.name)).toEqual([
+      "executeCommand",
+      "appendPrompt",
+      "showToast",
+    ])
+    expect(calls[0]?.input).toEqual({ body: { command: "session_new" } })
+
+    const appended = calls[1]?.input as { body: { text: string } }
+    expect(appended.body.text).toContain("Continuing work from session sess_source")
+    expect(appended.body.text).toContain("@src/files.ts @README.md")
+    expect(appended.body.text).toContain("Continue implementation")
+    expect(calls[2]?.input).toMatchObject({ body: { variant: "success" } })
+    expect(result).toContain("Review and edit")
+  })
+
+  test("builds a draft when no files are supplied", async () => {
+    const appendedPrompts: unknown[] = []
+    const client = {
+      tui: {
+        async executeCommand() {},
+        async appendPrompt(input: unknown) {
+          appendedPrompts.push(input)
+        },
+        async showToast() {},
+      },
+    } as unknown as OpencodeClient
+
+    await HandoffSession(client).execute(
+      { prompt: "Continue implementation" },
+      createToolContext("sess_source")
+    )
+
+    expect(appendedPrompts).toEqual([
+      {
+        body: {
+          text: [
+            "Continuing work from session sess_source. When you lack specific information you can use read_session to get it.",
+            "",
+            "Continue implementation",
+          ].join("\n"),
+        },
+      },
+    ])
+  })
+})
+
+describe("ReadSession", () => {
+  test("formats visible conversation content", async () => {
+    const requests: unknown[] = []
+    const client = {
+      session: {
+        async messages(input: unknown) {
+          requests.push(input)
+          return {
+            data: [
+              {
+                info: { role: "user" },
+                parts: [
+                  { type: "text", text: "hello" },
+                  { type: "text", text: "hidden", ignored: true },
+                  { type: "file", filename: "notes.txt" },
+                ],
+              },
+              {
+                info: { role: "assistant" },
+                parts: [
+                  { type: "text", text: "done" },
+                  {
+                    type: "tool",
+                    tool: "read",
+                    state: { status: "completed", title: "Read file" },
+                  },
+                  {
+                    type: "tool",
+                    tool: "write",
+                    state: { status: "running", title: "Writing" },
+                  },
+                ],
+              },
+            ],
+          }
+        },
+      },
+    } as unknown as OpencodeClient
+
+    const result = await ReadSession(client).execute(
+      { sessionID: "sess_old", limit: 2 },
+      createToolContext("sess_current")
+    )
+
+    expect(requests).toEqual([
+      { path: { id: "sess_old" }, query: { limit: 2 } },
+    ])
+    expect(result).toBe(
+      [
+        "## User",
+        "hello",
+        "[Attached: notes.txt]",
+        "",
+        "## Assistant",
+        "done",
+        "[Tool: read] Read file",
+        "",
+        "(Showing 2 most recent messages. Use a higher 'limit' to see more.)",
+      ].join("\n")
+    )
+  })
+
+  test("uses the default limit and handles an empty session", async () => {
+    const requests: unknown[] = []
+    const client = {
+      session: {
+        async messages(input: unknown) {
+          requests.push(input)
+          return { data: [] }
+        },
+      },
+    } as unknown as OpencodeClient
+
+    const result = await ReadSession(client).execute(
+      { sessionID: "sess_empty" },
+      createToolContext("sess_current")
+    )
+
+    expect(requests).toEqual([
+      { path: { id: "sess_empty" }, query: { limit: 100 } },
+    ])
+    expect(result).toBe("Session has no messages or does not exist.")
+  })
+
+  test("caps the limit and turns client errors into useful output", async () => {
+    const requests: unknown[] = []
+    const client = {
+      session: {
+        async messages(input: unknown) {
+          requests.push(input)
+          throw new Error("offline")
+        },
+      },
+    } as unknown as OpencodeClient
+
+    const result = await ReadSession(client).execute(
+      { sessionID: "sess_old", limit: 900 },
+      createToolContext("sess_current")
+    )
+
+    expect(requests).toEqual([
+      { path: { id: "sess_old" }, query: { limit: 500 } },
+    ])
+    expect(result).toBe("Could not read session sess_old: offline")
+  })
+})

--- a/test/vendor.test.ts
+++ b/test/vendor.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { formatFileContent } from "../src/vendor"
+
+describe("formatFileContent", () => {
+  test("limits line length and the number of lines", () => {
+    const content = [
+      "x".repeat(2001),
+      ...Array.from({ length: 2000 }, () => "line"),
+    ].join("\n")
+
+    const output = formatFileContent("ignored", content)
+
+    expect(output).toContain(`00001| ${"x".repeat(2000)}...`)
+    expect(output).toContain("02000| line")
+    expect(output).not.toContain("02001| line")
+    expect(output).toContain(
+      "(File has more lines. Use 'offset' parameter to read beyond line 2000)"
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- add a Bun test script and a dedicated pull-request test workflow
- cover file-reference parsing, synthetic file injection, and Read-compatible formatting limits
- cover both tools with small OpenCode client fakes
- cover command registration, message handling, session deduplication, and deletion cleanup

The suite follows the common pattern in tested OpenCode plugins: direct hook/tool invocation, handwritten boundary fakes, and real temporary files.

## Verification

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test` — 10 tests pass
- `bun test --coverage` — 100% functions, 98.78% lines
- `actionlint .github/workflows/*.yml`
- `uvx zizmor .`
- `bun pm pack --dry-run`